### PR TITLE
Added vga=ask to isolinux.cfg

### DIFF
--- a/boot/isolinux/isolinux.cfg
+++ b/boot/isolinux/isolinux.cfg
@@ -1,7 +1,7 @@
 DEFAULT tinycore
 LABEL tinycore
   KERNEL /boot/vmlinuz
-  APPEND initrd=/boot/core.gz quiet console=tty9 loglevel=0 host=tc
+  APPEND initrd=/boot/core.gz quiet console=tty9 loglevel=0 host=tc vga=ask
   TIMEOUT 0
   PROMPT 0
 


### PR DESCRIPTION
Thanks to this, you can choose the native monitor resolution. Helpful using CSMWrap on computers with UEFI bios without CSM - tested on Dell Wyse 5070